### PR TITLE
usage if no arguments are passed

### DIFF
--- a/pen.c
+++ b/pen.c
@@ -3702,9 +3702,11 @@ int main(int argc, char **argv)
 	argc -= n;
 	argv += n;
 
+#ifndef WINDOWS
 	if (argc < 1) {
 		usage();
 	}
+#endif
 	now = time(NULL);
 #ifdef WINDOWS
 	start_winsock();

--- a/pen.c
+++ b/pen.c
@@ -3702,6 +3702,9 @@ int main(int argc, char **argv)
 	argc -= n;
 	argv += n;
 
+	if (argc < 1) {
+		usage();
+	}
 	now = time(NULL);
 #ifdef WINDOWS
 	start_winsock();


### PR DESCRIPTION
Call usage() if no arguments are passed. This was removed in 2d957fbbb774c2e5af2170282b5e8e21da194e44
