### PR TITLE
man: fix NAME section of manual pages

### DIFF
--- a/mergelogs.1
+++ b/mergelogs.1
@@ -1,7 +1,7 @@
 .TH MERGELOGS 1 LOCAL
 
 .SH NAME
-mergelogs
+mergelogs - merge and consolidate web server logs
 
 .SH SYNOPSIS
 .B mergelogs

--- a/pen.1
+++ b/pen.1
@@ -1,11 +1,13 @@
 .TH PEN 1 LOCAL
 
 .SH NAME
-pen
+pen - Load balancer for "simple" tcp based protocols
 
 .SH SYNOPSIS
 .B pen
+.na
 [-b sec] [-S N] [-c N] [-e host:port] [-t sec] [-x N] [-j dir] [-u user] [-F cfgfile] [-l logfile] [-p file ] [-w file] [-C port|/path/to/socket] [-T sec] [-HWXadfhrs] [-o option] [-E certfile] [-K keyfile] [-G cacertfile] [-A cacertdir] [-Z] [-R] [-L protocol] [host:]port|/path/to/socket h1[:p1[:maxc1[:hard1[:weight1[:prio1]]]]] [h2[:p2[:maxc2[:hard2[:weight2[:prio2]]]]]] ...
+.ad
 
 Windows only:
 

--- a/penctl.1
+++ b/penctl.1
@@ -1,7 +1,7 @@
 .TH PENCTL 1 LOCAL
 
 .SH NAME
-penctl
+penctl - control a running pen load balancer
 
 .SH SYNOPSIS
 .B penctl

--- a/penlog.1
+++ b/penlog.1
@@ -1,7 +1,7 @@
 .TH PENLOG 1 LOCAL
 
 .SH NAME
-penlog
+penlog - pipe Apache logs to penlogd
 
 .SH SYNOPSIS
 .B penlog

--- a/penlogd.1
+++ b/penlogd.1
@@ -1,7 +1,7 @@
 .TH PENLOGD 1 LOCAL
 
 .SH NAME
-penlogd
+penlogd - consolidate web server logs
 
 .SH SYNOPSIS
 .B penlogd


### PR DESCRIPTION
To be able to parse a manual page, lexgrog needs the NAME section
containing a description. If lexgrog is not able to parse the manual
page NAME section, the manual page cannot be found with whatis.