### PR TITLE
git: ignore autoconf/automake files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# autoconf/automake
+Makefile.in
+/aclocal.m4
+/autom4te.cache/
+/compile
+/configure
+/depcomp
+/install-sh
+/ltmain.sh
+/missing


### PR DESCRIPTION
Those files are generated by `bootstrap.sh`. They should be
ignored. Note that files generated by `configure` are not ignored.

As I am always using out-of-tree build, I didn't add more files.