### PR TITLE
ssl: fix segfault when not using SSL

### DIFF
--- a/pen.c
+++ b/pen.c
@@ -1702,7 +1702,9 @@ static void add_client(int downfd, struct sockaddr_storage *cli_addr)
 #ifdef HAVE_LIBSSL
 	conn = store_conn(downfd, ssl, client);
 	conns[conn].reneg = 0;	/* never */
-	SSL_set_app_data(ssl, &conns[conn]);
+	if (ssl) {
+		SSL_set_app_data(ssl, &conns[conn]);
+	}
 #else
 	conn = store_conn(downfd, client);
 #endif


### PR DESCRIPTION
When not using SSL, we get the following segfault:

    #0  0x00007f4245dea5b3 in CRYPTO_set_ex_data () from /usr/lib/x86_64-linux-gnu/libcrypto.so.1.0.0
    No symbol table info available.
    #1  0x0000000000409599 in add_client (downfd=7, cli_addr=0x7fffae810c90) at ../pen.c:1705
            rc = 0
            b = '\000' <repeats 12720 times>...
            client = 0
            conn = 0
            ssl = 0x0

This is a regression introduced in commit
05bd3b51944cb97eba916ba5a8e86793b133951c.