### PR TITLE
fix valgrind warning. initialized event structure

### DIFF
--- a/epoll.c
+++ b/epoll.c
@@ -20,6 +20,7 @@ static void epoll_event_ctl(int fd, int events, int op)
 {
 	int n, epevents = 0;
 	struct epoll_event ev;
+	memset(&ev, 0, sizeof(struct epoll_event));
 	DEBUG(2, "epoll_event_ctl(fd=%d, events=%d, op=%d)", fd, events, op);
 	if (events & EVENT_READ) epevents |= EPOLLIN;
 	if (events & EVENT_WRITE) epevents |= EPOLLOUT;


### PR DESCRIPTION
```
==10136== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==10136==    at 0x38CCCE8E9A: epoll_ctl (syscall-template.S:82)
==10136==    by 0x409D34: epoll_event_ctl (epoll.c:28)
==10136==    by 0x407727: mainloop (pen.c:2215)
==10136==    by 0x408DEC: main (pen.c:2545)
==10136==  Address 0x7ff000018 is on thread 1's stack
==10136==
==10136== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==10136==    at 0x38CCCE8E9A: epoll_ctl (syscall-template.S:82)
==10136==    by 0x409D34: epoll_event_ctl (epoll.c:28)
==10136==    by 0x407748: mainloop (pen.c:2217)
==10136==    by 0x408DEC: main (pen.c:2545)
==10136==  Address 0x7ff000018 is on thread 1's stack
==10136==                                                             
==10136== Syscall param epoll_ctl(event) points to uninitialised byte(s)
==10136==    at 0x38CCCE8E9A: epoll_ctl (syscall-template.S:82)          
==10136==    by 0x409D34: epoll_event_ctl (epoll.c:28)             
==10136==    by 0x408028: mainloop (pen.c:2099)          
==10136==    by 0x408DEC: main (pen.c:2545)
==10136==  Address 0x7ff000018 is on thread 1's stack           
==10136== 
```