### PR TITLE
Make server_by_roundrobin start from server 0

### DIFF
--- a/server.c
+++ b/server.c
@@ -176,16 +176,16 @@ static int server_by_prio(void)
 
 int server_by_roundrobin(void)
 {
-	static int last_server = 0;
-	int i = last_server;
+	static int last_server = -1;
+	int i, j;
 
 	if (nservers == 0) return NO_SERVER;
-	do {
+	for (i = last_server, j = 0; j < nservers; j++) {
 		i = (i+1) % (nservers?nservers:1);
 		DEBUG(3, "server_by_roundrobin considering server %d", i);
 		if (!server_is_unavailable(i)) return (last_server = i);
 		DEBUG(3, "server %d is unavailable, try next one", i);
-	} while (i != last_server);
+	}
 	return NO_SERVER;
 }
 


### PR DESCRIPTION
This is not a bug, but I think it's better to start from server 0, rather than server 1 in `server_by_roundrobin`.

Before:
<img width="644" alt="snipaste_2019-03-04_11-21-01" src="https://user-images.githubusercontent.com/568900/53708703-a3170e80-3e6f-11e9-9a69-840034bf10ca.png">


After:


<img width="668" alt="snipaste_2019-03-04_11-22-26" src="https://user-images.githubusercontent.com/568900/53708766-ebcec780-3e6f-11e9-8235-3091093202f7.png">
