### PR TITLE
DSR did not update, check or invaildate server[x].status

### DIFF
--- a/pen.c
+++ b/pen.c
@@ -1504,6 +1504,13 @@ static void do_cmd(char *b, void (*output)(void *, char *, ...), void *op)
 				servers[n].prio = atoi(q);
 			}
 		}
+		if (dsr_if) {
+			// if dsr, invalid the hash table, otherwise
+			// these settings never take effect.
+			server_alg ^= ALG_HASH_VALID;
+			DEBUG(2, "do_cmd() - if dsr_if - invalidating hash");
+		}
+
 	} else if (!strcmp(p, "servers")) {
 		for (n = 0; n < nservers; n++) {
 			output(op,


### PR DESCRIPTION
When using the evaluating and testing, I was trying to manually take a server out of rotation, as documented in the example at http://siag.nu/hypermail/pen/0038.html

Using for example :
    `penctl localhost:8888 server 0 blacklist 300`

The server was not being taking out of rotation.   As far as I could tell, try_server(), which should update server[x].status was not being called in the DSR mode.  In additionally, in pen.c:do_cmd(), when running `penctl socket server X ...`  for any of the servers settings the DSR hashing table is never invalidated  `server_alg ^= ALG_HASH_VALID` 

Also, there was no regular checking for for the blacklist timeout.  The logical place seemed to be dsr.c:dsr_arp().  Added one new global last_hash_rebuild, and using the blacklist_time global as the a forced periodic server table rehashing, and is of course forced when penctl updates a server. 

Added some more debugging to help follow the logic and verify.    I have not verified the do_cmd() outside of DSR mode.